### PR TITLE
Remove sorting Events by id

### DIFF
--- a/app/reducers/events.js
+++ b/app/reducers/events.js
@@ -1,4 +1,4 @@
-import { unionWith, sortWith, ascend, prop, eqBy } from 'ramda';
+import { unionWith, prop, eqBy } from 'ramda';
 import {
   EVENTS_FETCH_REQUEST,
   EVENTS_FETCH_SUCCESS,
@@ -8,9 +8,6 @@ import {
 } from '../constants/actionTypes';
 
 const comparator = eqBy(prop('id'));
-const sortById = sortWith([
-  ascend(prop('id')),
-]);
 
 export const initialState = {
   isStarted: false,
@@ -36,11 +33,11 @@ export default function events(state = initialState, action) {
       return {
         ...state,
         isFetching: false,
-        items: sortById(unionWith(
+        items: unionWith(
           comparator,
-          items,
           state.items,
-        )),
+          items,
+        ),
         links,
       };
     case EVENTS_FETCH_FAILURE:
@@ -58,7 +55,7 @@ export default function events(state = initialState, action) {
       return {
         ...state,
         isRefreshing: false,
-        items: sortById(items),
+        items,
         links,
       };
     default:


### PR DESCRIPTION
### Changes in PR
* Remove sorting Events by id (it was causing wrong sort because ids are strings and it was 1, 10, 11, 12 ... 2, 3...)
